### PR TITLE
fix: update task name to be Notation

### DIFF
--- a/NotationV0/task.json
+++ b/NotationV0/task.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/Microsoft/azure-pipelines-task-lib/master/tasks.schema.json",
     "id": "f7d56ba6-35a6-453d-8192-8b602bf234bd",
-    "name": "notation",
+    "name": "Notation",
     "friendlyName": "Notation",
     "description": "Azure Pipepine Task for setting up Notation CLI, sign and verify with Notation",
     "helpMarkDown": "",

--- a/README.md
+++ b/README.md
@@ -44,13 +44,13 @@ steps:
     command: 'buildAndPush'
     Dockerfile: './Dockerfile'
 # install notation
-- task: notation@0
+- task: Notation@0
   inputs:
     command: 'install'
     version: '1.0.0'
 # automatically detect the artifact pushed by Docker task 
 # and sign the artifact.
-- task: notation@0
+- task: Notation@0
   inputs:
     version: '1.0.0'
     command: 'sign'
@@ -73,12 +73,12 @@ steps:
     containerRegistry: <docker_registry_service_connection>
     command: 'login'
 # install notation
-- task: notation@0
+- task: Notation@0
   inputs:
     command: 'install'
     version: '1.0.0'
 # sign the artifact
-- task: notation@0
+- task: Notation@0
   inputs:
     artifactRefs: '<registry_host>/<repository>@<digest>'
     command: 'sign'
@@ -102,7 +102,7 @@ steps:
     containerRegistry: <docker_registry_service_connection>
     command: 'login'
 # notation verify
-- task: notation@0
+- task: Notation@0
   inputs:
     command: 'verify'
     artifactRefs: '<registry_host>/<repository>@<digest>'


### PR DESCRIPTION
Fix:
- update the task name to be `Notation` instead of `notation` to follow the convention

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>